### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,5 +28,5 @@ The [`install-or-tools.sh`](./install-or-tools.sh) shell script downloads Google
 We can use the solver with the name `or-tools`.
 
 ```bash
-minizinc --solver or-tools
+minizinc --solvers or-tools
 ```


### PR DESCRIPTION
Hey, I think it should worked with "solvers".
Corrected: "minizinc --solvers or-tools"

please check below commands:

nnagar@compute4:~/install-minizinc-ortools$ minizinc --solver or-tools 
Error: no model file given.
nnagar@compute4:~/install-minizinc-ortools$ minizinc --solvers or-tools MiniZinc driver.
Available solver configurations:
  Gecode 6.2.0 (org.gecode.gecode, cp, int, float, set, restart)
  Gecode Gist 6.2.0 (org.gecode.gist, cp, int, float, set, restart)
  OR-Tools 9.1.9490 (com.google.or-tools, cp, int)
Search path for solver configurations:
  /home/nnagar/.minizinc/solvers
  /usr/share/minizinc/solvers
  /usr/local/share/minizinc/solvers